### PR TITLE
fix: Fix copy feature doesn't work as expected

### DIFF
--- a/src/components/OverviewItem.tsx
+++ b/src/components/OverviewItem.tsx
@@ -9,6 +9,7 @@ import Description from './Description';
 interface OverviewItemProps {
   subject: string;
   value: unknown;
+  children?: React.ReactNode;
   copyable?: boolean;
   subjectWidth?: string | number;
 }
@@ -16,6 +17,7 @@ interface OverviewItemProps {
 export default function OverviewItem({
   subject,
   value,
+  children,
   copyable,
   subjectWidth,
 }: OverviewItemProps) {
@@ -35,7 +37,9 @@ export default function OverviewItem({
         {subject}
       </Typography>
 
-      <Description copyable={!!value && copyable}>{value}</Description>
+      <Description value={value} copyable={!!value && copyable}>
+        {children ?? value}
+      </Description>
     </Stack>
   );
 }

--- a/src/view/TransactionView.tsx
+++ b/src/view/TransactionView.tsx
@@ -20,11 +20,9 @@ export default function TransactionView({ transaction }: TransactionViewProps) {
 
   const sections = {
     slot: (
-      <OverviewItem
-        subject="Slot"
-        value={<Link href={`/blocks/${transaction.slot}`}>{transaction.slot}</Link>}
-        copyable
-      />
+      <OverviewItem subject="Slot" value={transaction.slot} copyable>
+        <Link href={`/blocks/${transaction.slot}`}>{transaction.slot}</Link>
+      </OverviewItem>
     ),
 
     signature: (


### PR DESCRIPTION
it copy `[Object Object]` when user click the copy icon for the slot in transaction detail page